### PR TITLE
Fix minutes left in error message

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -133,7 +133,7 @@ def main():
     # minutes buffer is how low the minutes should get before failing and raising an alarm
     if remaining_minutes < int(raise_alarm_remaining_minutes):
         raise RemainingMinutesThresholdError(
-            f'Your organisation is running short on minutes, you have {raise_alarm_remaining_minutes} left')
+            f'Your organisation is running short on minutes, you have {remaining_minutes} left')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description
Tested out the scheduled github-actions-usage as Github Action and found the error message reflecting the `raise_alarm_remaining_minutes` instead of the actual minutes remaining.

![image](https://user-images.githubusercontent.com/102711706/204070156-ec436de1-0eb8-4f49-ba64-73b71d30cd8a.png)


## Type of change
variable in `main.py`

## How Has This Been Tested?
Run the test using python.

![image](https://user-images.githubusercontent.com/102711706/204070164-9a3d15f4-28f7-41e5-96b8-139e6caa344c.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have labelled my PR 
